### PR TITLE
Add initial CurlDebuggerVisualizer2 implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Visual Studio
+bin/
+obj/
+.vs/
+*~
+*.user
+*.suo

--- a/CurlDebuggerVisualizer.sln
+++ b/CurlDebuggerVisualizer.sln
@@ -1,0 +1,18 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CurlDebuggerVisualizer", "CurlDebuggerVisualizer\CurlDebuggerVisualizer.csproj", "{566E7877-32DA-44E2-A6BE-30D8439CD50A}"
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {566E7877-32DA-44E2-A6BE-30D8439CD50A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {566E7877-32DA-44E2-A6BE-30D8439CD50A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {566E7877-32DA-44E2-A6BE-30D8439CD50A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {566E7877-32DA-44E2-A6BE-30D8439CD50A}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
+EndGlobal

--- a/CurlDebuggerVisualizer/Assets/template.html
+++ b/CurlDebuggerVisualizer/Assets/template.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>HTTP Response</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />
+    <style>
+        body { margin:0; padding:0; }
+        pre { white-space: pre-wrap; word-break: break-all; }
+    </style>
+</head>
+<body>
+    <div class="container-fluid p-2">
+        <ul class="nav nav-tabs" id="respTab" role="tablist">
+            <li class="nav-item" role="presentation">
+                <button class="nav-link active" id="curl-tab" data-bs-toggle="tab" data-bs-target="#curl" type="button" role="tab">cURL</button>
+            </li>
+            <li class="nav-item" role="presentation">
+                <button class="nav-link" id="raw-tab" data-bs-toggle="tab" data-bs-target="#raw" type="button" role="tab">Raw</button>
+            </li>
+            <li class="nav-item" role="presentation">
+                <button class="nav-link" id="json-tab" data-bs-toggle="tab" data-bs-target="#json" type="button" role="tab">JSON</button>
+            </li>
+        </ul>
+        <div class="tab-content mt-3">
+            <div class="tab-pane fade show active" id="curl" role="tabpanel">
+                <pre>{{CURL_COMMAND}}</pre>
+            </div>
+            <div class="tab-pane fade" id="raw" role="tabpanel">
+                <pre>{{RAW_RESPONSE}}</pre>
+            </div>
+            <div class="tab-pane fade" id="json" role="tabpanel">
+                <pre>{{PRETTY_JSON}}</pre>
+            </div>
+        </div>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/CurlDebuggerVisualizer/CurlDebuggerVisualizer.csproj
+++ b/CurlDebuggerVisualizer/CurlDebuggerVisualizer.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <UseWPF>true</UseWPF>
+    <AssemblyName>CurlDebuggerVisualizer2</AssemblyName>
+    <RootNamespace>CurlDebuggerVisualizer</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.DebuggerVisualizers" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2210.55" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+</Project>

--- a/CurlDebuggerVisualizer/CurlHelper.cs
+++ b/CurlDebuggerVisualizer/CurlHelper.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Net.Http;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace CurlDebuggerVisualizer
+{
+    public static class CurlHelper
+    {
+        public static string ToCurlCommand(HttpRequestMessage request)
+        {
+            if (request == null) return string.Empty;
+
+            var builder = new StringBuilder();
+            builder.Append("curl");
+            builder.Append(" -X ").Append(request.Method.Method);
+
+            foreach (var header in request.Headers)
+            {
+                foreach (var value in header.Value)
+                {
+                    builder.Append(" -H \"")
+                           .Append(header.Key).Append(": ").Append(value).Append("\"");
+                }
+            }
+
+            if (request.Content != null)
+            {
+                foreach (var header in request.Content.Headers)
+                {
+                    foreach (var value in header.Value)
+                    {
+                        builder.Append(" -H \"")
+                               .Append(header.Key).Append(": ").Append(value).Append("\"");
+                    }
+                }
+
+                var content = request.Content.ReadAsStringAsync().Result;
+                if (!string.IsNullOrEmpty(content))
+                {
+                    builder.Append(" --data \"")
+                           .Append(content.Replace("\"", "\\\"") )
+                           .Append("\"");
+                }
+            }
+
+            builder.Append(" \"").Append(request.RequestUri).Append("\"");
+            return builder.ToString();
+        }
+
+        public static string ToRawResponse(HttpResponseMessage response)
+        {
+            if (response == null) return string.Empty;
+
+            var sb = new StringBuilder();
+            sb.Append("HTTP/").Append(response.Version)
+              .Append(' ').Append((int)response.StatusCode)
+              .Append(' ').Append(response.ReasonPhrase).AppendLine();
+
+            foreach (var header in response.Headers)
+            {
+                foreach (var value in header.Value)
+                {
+                    sb.Append(header.Key).Append(": ").Append(value).AppendLine();
+                }
+            }
+            if (response.Content != null)
+            {
+                foreach (var header in response.Content.Headers)
+                {
+                    foreach (var value in header.Value)
+                    {
+                        sb.Append(header.Key).Append(": ").Append(value).AppendLine();
+                    }
+                }
+                sb.AppendLine();
+                sb.Append(response.Content.ReadAsStringAsync().Result);
+            }
+
+            return sb.ToString();
+        }
+
+        public static string ToPrettyJson(string json)
+        {
+            if (string.IsNullOrWhiteSpace(json)) return string.Empty;
+            try
+            {
+                var obj = JsonConvert.DeserializeObject(json);
+                return JsonConvert.SerializeObject(obj, Formatting.Indented);
+            }
+            catch
+            {
+                return json;
+            }
+        }
+    }
+}

--- a/CurlDebuggerVisualizer/CurlResponseVisualizer.cs
+++ b/CurlDebuggerVisualizer/CurlResponseVisualizer.cs
@@ -1,0 +1,47 @@
+using System.Net.Http;
+using Microsoft.VisualStudio.DebuggerVisualizers;
+
+[assembly: System.Diagnostics.DebuggerVisualizer(
+    typeof(CurlDebuggerVisualizer.CurlResponseVisualizer),
+    typeof(VisualizerObjectSource),
+    Target = typeof(HttpResponseMessage),
+    Description = "cURL Debugger Visualizer")]
+
+namespace CurlDebuggerVisualizer
+{
+    public class CurlResponseVisualizer : DialogDebuggerVisualizer
+    {
+        protected override void Show(IDialogVisualizerService windowService, IVisualizerObjectProvider objectProvider)
+        {
+            if (windowService == null || objectProvider == null) return;
+
+            HttpResponseMessage response = null;
+            if (objectProvider is IVisualizerObjectProvider3 provider3)
+            {
+                response = provider3.GetObject<HttpResponseMessage>();
+            }
+
+            if (response == null) return;
+
+            var request = response.RequestMessage;
+            string curl = CurlHelper.ToCurlCommand(request);
+            string raw = CurlHelper.ToRawResponse(response);
+            string json = string.Empty;
+
+            if (response.Content?.Headers?.ContentType != null &&
+                response.Content.Headers.ContentType.MediaType.Contains("application/json"))
+            {
+                json = CurlHelper.ToPrettyJson(response.Content.ReadAsStringAsync().Result);
+            }
+
+            var form = new CurlResponseVisualizerForm(curl, raw, json);
+            windowService.ShowDialog(form);
+        }
+
+        public static void TestShowVisualizer(HttpResponseMessage response)
+        {
+            var host = new VisualizerDevelopmentHost(response, typeof(CurlResponseVisualizer));
+            host.ShowVisualizer();
+        }
+    }
+}

--- a/CurlDebuggerVisualizer/CurlResponseVisualizerForm.xaml
+++ b/CurlDebuggerVisualizer/CurlResponseVisualizerForm.xaml
@@ -1,0 +1,8 @@
+<Window x:Class="CurlDebuggerVisualizer.CurlResponseVisualizerForm"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="cURL Debugger Visualizer" Height="600" Width="800">
+    <Grid>
+        <WebView2 x:Name="Browser" />
+    </Grid>
+</Window>

--- a/CurlDebuggerVisualizer/CurlResponseVisualizerForm.xaml.cs
+++ b/CurlDebuggerVisualizer/CurlResponseVisualizerForm.xaml.cs
@@ -1,0 +1,38 @@
+using System.IO;
+using System.Reflection;
+using System.Windows;
+using Microsoft.Web.WebView2.Wpf;
+
+namespace CurlDebuggerVisualizer
+{
+    public partial class CurlResponseVisualizerForm : Window
+    {
+        private readonly string _curl;
+        private readonly string _raw;
+        private readonly string _json;
+
+        public CurlResponseVisualizerForm(string curlCommand, string rawResponse, string prettyJson)
+        {
+            InitializeComponent();
+            _curl = curlCommand;
+            _raw = rawResponse;
+            _json = prettyJson;
+            Loaded += CurlResponseVisualizerForm_Loaded;
+        }
+
+        private async void CurlResponseVisualizerForm_Loaded(object sender, RoutedEventArgs e)
+        {
+            await Browser.EnsureCoreWebView2Async();
+
+            var assembly = Assembly.GetExecutingAssembly();
+            var path = Path.Combine(Path.GetDirectoryName(assembly.Location) ?? string.Empty, "Assets", "template.html");
+            var html = File.ReadAllText(path);
+
+            html = html.Replace("{{CURL_COMMAND}}", System.Net.WebUtility.HtmlEncode(_curl))
+                       .Replace("{{RAW_RESPONSE}}", System.Net.WebUtility.HtmlEncode(_raw))
+                       .Replace("{{PRETTY_JSON}}", System.Net.WebUtility.HtmlEncode(_json));
+
+            Browser.NavigateToString(html);
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# CurlDebuggerVisualizer2
+
+A Visual Studio debugger visualizer to inspect `HttpResponseMessage` objects with a modern UI using WPF and WebView2.
+
+## Building
+
+Open `CurlDebuggerVisualizer.sln` with Visual Studio 2022 and restore NuGet packages. The project targets **.NET Framework 4.8** and requires the **WebView2** runtime.
+
+## Deploying
+
+After building the project, copy `CurlDebuggerVisualizer2.dll` from the `bin/Release` folder to:
+
+```
+%USERPROFILE%\Documents\Visual Studio 2022\Visualizers\
+```
+
+Restart Visual Studio if it was running.
+
+## Testing
+
+1. Create or open a project that performs an HTTP request using `HttpClient`.
+2. Place a breakpoint after receiving the `HttpResponseMessage`.
+3. Start debugging and when the breakpoint hits, hover over the variable or add it to the Watch window.
+4. Click the magnifier icon to launch the **CurlDebuggerVisualizer2** window.
+5. Inspect the cURL command, raw response, and pretty JSON in the visualizer.
+
+## Repository Structure
+
+```
+CurlDebuggerVisualizer2
+├── CurlDebuggerVisualizer.sln
+├── CurlDebuggerVisualizer (WPF Class Library)
+│   ├── Assets
+│   │   └── template.html
+│   ├── CurlHelper.cs
+│   ├── CurlResponseVisualizer.cs
+│   ├── CurlResponseVisualizerForm.xaml
+│   └── CurlResponseVisualizerForm.xaml.cs
+├── README.md
+└── PROMPT.md
+```
+
+This repository provides a simple but functional starting point for creating modern debugger visualizers for Visual Studio.


### PR DESCRIPTION
## Summary
- implement WPF class library for visualizing HttpResponseMessage
- add dialog visualizer and helper utilities
- add WebView2 based form with HTML template
- add README with build and deployment instructions

## Testing
- `msbuild CurlDebuggerVisualizer.sln -restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843943dd448833397f3c52022d646b1