### PR TITLE
Add VSIX build and CI workflow

### DIFF
--- a/.github/workflows/build-vsix.yml
+++ b/.github/workflows/build-vsix.yml
@@ -1,0 +1,24 @@
+name: Build VSIX
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v1.1
+      - name: Restore
+        run: msbuild CurlDebuggerVisualizer.sln /t:Restore
+      - name: Build
+        run: msbuild CurlDebuggerVisualizer.sln /p:Configuration=Release
+      - name: Archive VSIX
+        uses: actions/upload-artifact@v3
+        with:
+          name: CurlDebuggerVisualizer
+          path: CurlDebuggerVisualizer.VSIX/bin/Release/*.vsix

--- a/CurlDebuggerVisualizer.VSIX/CurlDebuggerVisualizer.VSIX.csproj
+++ b/CurlDebuggerVisualizer.VSIX/CurlDebuggerVisualizer.VSIX.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
+    <UseCodebase>true</UseCodebase>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.5.3340" PrivateAssets="all" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="source.extension.vsixmanifest" />
+    <Content Include="..\CurlDebuggerVisualizer\bin\$(Configuration)\net48\CurlDebuggerVisualizer2.dll">
+      <Link>CurlDebuggerVisualizer2.dll</Link>
+    </Content>
+  </ItemGroup>
+</Project>

--- a/CurlDebuggerVisualizer.VSIX/source.extension.vsixmanifest
+++ b/CurlDebuggerVisualizer.VSIX/source.extension.vsixmanifest
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011">
+  <Metadata>
+    <Identity Id="CurlDebuggerVisualizer2" Version="1.0" Language="en-US" Publisher="Sample" />
+    <DisplayName>Curl Debugger Visualizer</DisplayName>
+    <Description>Debugger visualizer for HttpResponseMessage objects.</Description>
+  </Metadata>
+  <Installation>
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0,18.0)" />
+  </Installation>
+  <Dependencies>
+    <Dependency Id="Microsoft.Framework.NDP" Version="[4.8,)" DisplayName=".NET Framework" />
+  </Dependencies>
+  <Assets>
+    <Asset Type="File" Path="CurlDebuggerVisualizer2.dll" />
+  </Assets>
+</PackageManifest>

--- a/CurlDebuggerVisualizer.sln
+++ b/CurlDebuggerVisualizer.sln
@@ -1,18 +1,24 @@
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31912.275
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CurlDebuggerVisualizer", "CurlDebuggerVisualizer\CurlDebuggerVisualizer.csproj", "{566E7877-32DA-44E2-A6BE-30D8439CD50A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CurlDebuggerVisualizer.VSIX", "CurlDebuggerVisualizer.VSIX\CurlDebuggerVisualizer.VSIX.csproj", "{D7C23F8A-2744-4317-8107-A8A2E2FD160B}"
+EndProject
 Global
-    GlobalSection(SolutionConfigurationPlatforms) = preSolution
-        Debug|Any CPU = Debug|Any CPU
-        Release|Any CPU = Release|Any CPU
-    EndGlobalSection
-    GlobalSection(ProjectConfigurationPlatforms) = postSolution
-        {566E7877-32DA-44E2-A6BE-30D8439CD50A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-        {566E7877-32DA-44E2-A6BE-30D8439CD50A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-        {566E7877-32DA-44E2-A6BE-30D8439CD50A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-        {566E7877-32DA-44E2-A6BE-30D8439CD50A}.Release|Any CPU.Build.0 = Release|Any CPU
-    EndGlobalSection
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{566E7877-32DA-44E2-A6BE-30D8439CD50A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{566E7877-32DA-44E2-A6BE-30D8439CD50A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{566E7877-32DA-44E2-A6BE-30D8439CD50A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{566E7877-32DA-44E2-A6BE-30D8439CD50A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D7C23F8A-2744-4317-8107-A8A2E2FD160B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D7C23F8A-2744-4317-8107-A8A2E2FD160B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D7C23F8A-2744-4317-8107-A8A2E2FD160B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D7C23F8A-2744-4317-8107-A8A2E2FD160B}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
 EndGlobal

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ A Visual Studio debugger visualizer to inspect `HttpResponseMessage` objects wit
 
 Open `CurlDebuggerVisualizer.sln` with Visual Studio 2022 and restore NuGet packages. The project targets **.NET Framework 4.8** and requires the **WebView2** runtime.
 
+### Building a VSIX Package
+
+The solution includes a `CurlDebuggerVisualizer.VSIX` project that packages the
+visualizer as a VSIX extension. You can build it locally with Visual Studio or
+let GitHub Actions build it for you. On every push or pull request to `main` or
+`master`, the workflow located at `.github/workflows/build-vsix.yml` will run and
+produce a VSIX artifact.
+
 ## Deploying
 
 After building the project, copy `CurlDebuggerVisualizer2.dll` from the `bin/Release` folder to:


### PR DESCRIPTION
## Summary
- package the debugger visualizer as a VSIX extension
- add GitHub Actions workflow to build the VSIX package
- document VSIX build instructions

## Testing
- `dotnet build CurlDebuggerVisualizer.sln -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68440a9f7f4483338bd2690bca62ac52